### PR TITLE
chore: Migrating the gap property to use the `Config.spacing` type instead of `Length.t`

### DIFF
--- a/lib/src/core/css/Ancestor_Css.res
+++ b/lib/src/core/css/Ancestor_Css.res
@@ -456,25 +456,26 @@ module Make = (
   }
 
   module Gap = {
-    type t = [#v(array<Config.spacing>) | #inherit | #initial | #revert | #unset]
-    let spacingToString = v => v->Config.spacing->Length.toString
-    let getFirstTwoValues = arr => {
-      let value = arr->Belt.Array.get(0)->Belt.Option.mapWithDefault(`0`, spacingToString)
-      let value2 = arr->Belt.Array.get(1)->Belt.Option.mapWithDefault(`0`, spacingToString)
+    type t = [
+      | #one(Config.spacing)
+      | #two(Config.spacing, Config.spacing)
+      | #inherit
+      | #initial
+      | #revert
+      | #unset
+    ]
 
-      `${value} ${value2}`
-    }
-
-    let toString = (gap: t) =>
+    let toString = (gap: t) => {
+      let spacingToString = v => v->Config.spacing->Length.toString
       switch gap {
-      | #v([]) => `0 0`
-      | #v([value]) => value->spacingToString
-      | #v(values) => values->getFirstTwoValues
+      | #one(v) => v->spacingToString
+      | #two(v1, v2) => `${v1->spacingToString} ${v2->spacingToString}`
       | #inherit => "inherit"
       | #initial => "initial"
       | #revert => "revert"
       | #unset => "unset"
       }
+    }
   }
 
   module Position = {

--- a/lib/src/core/css/Ancestor_Css.res
+++ b/lib/src/core/css/Ancestor_Css.res
@@ -456,12 +456,20 @@ module Make = (
   }
 
   module Gap = {
-    type t = [#one(Length.t) | #two(Length.t, Length.t) | #inherit | #initial | #revert | #unset]
+    type t = [#v(array<Config.spacing>) | #inherit | #initial | #revert | #unset]
+    let spacingToString = v => v->Config.spacing->Length.toString
+    let getFirstTwoValues = arr => {
+      let value = arr->Belt.Array.get(0)->Belt.Option.mapWithDefault(`0`, spacingToString)
+      let value2 = arr->Belt.Array.get(1)->Belt.Option.mapWithDefault(`0`, spacingToString)
+
+      `${value} ${value2}`
+    }
 
     let toString = (gap: t) =>
       switch gap {
-      | #one(value) => value->Length.toString
-      | #two(value1, value2) => `${value1->Length.toString} ${value2->Length.toString}`
+      | #v([]) => `0 0`
+      | #v([value]) => value->spacingToString
+      | #v(values) => values->getFirstTwoValues
       | #inherit => "inherit"
       | #initial => "initial"
       | #revert => "revert"

--- a/lib/src/core/css/Ancestor_Css_Test.res
+++ b/lib/src/core/css/Ancestor_Css_Test.res
@@ -60,8 +60,8 @@ describe("Ancestor_Css", (. ()) => {
     it("should convert into string correctly", (. ()) => {
       let {toString} = module(Gap)
 
-      expect(#v([1])->toString)->toBe(`8.0px`)
-      expect(#v([1, 1])->toString)->toBe(`8.0px 8.0px`)
+      expect(#one(1)->toString)->toBe(`8px`)
+      expect(#two(1, 2)->toString)->toBe(`8px 16px`)
 
       expect(#inherit->toString)->toBe(`inherit`)
       expect(#unset->toString)->toBe(`unset`)

--- a/lib/src/core/css/Ancestor_Css_Test.res
+++ b/lib/src/core/css/Ancestor_Css_Test.res
@@ -1,4 +1,5 @@
 open Ancestor_Jest
+
 include Ancestor_Css.Make({
   type spacing = int
   let spacing = v => #px(v * 8)
@@ -8,7 +9,6 @@ describe("Ancestor_Css", (. ()) => {
   describe("Length.toString", (. ()) => {
     it("should convert into string correctly", (. ()) => {
       let {toString} = module(Length)
-
       expect(toString(#rem(10.2)))->toBe(`10.2rem`)
       expect(toString(#em(7.5)))->toBe(`7.5em`)
       expect(toString(#px(1)))->toBe(`1px`)
@@ -60,8 +60,8 @@ describe("Ancestor_Css", (. ()) => {
     it("should convert into string correctly", (. ()) => {
       let {toString} = module(Gap)
 
-      expect(#one(12.5->#rem)->toString)->toBe(`12.5rem`)
-      expect(#two(5->#px, 10.5->#rem)->toString)->toBe(`5px 10.5rem`)
+      expect(#v([1])->toString)->toBe(`8.0px`)
+      expect(#v([1, 1])->toString)->toBe(`8.0px 8.0px`)
 
       expect(#inherit->toString)->toBe(`inherit`)
       expect(#unset->toString)->toBe(`unset`)


### PR DESCRIPTION
Closes #42 
> ⚠️  This is a breaking change.