### PR TITLE
doc: correct `CSS Key` of System Prop `m`

### DIFF
--- a/website/docs/system-props.md
+++ b/website/docs/system-props.md
@@ -80,7 +80,7 @@ Check out the [`Config.spacing`](/docs/system-props#configspacing) type signatur
 
 #### `m`
 
-- CSS Key: `padding`
+- CSS Key: `margin`
 - Type: `responsiveProp<Config.spacing>`
 
 #### `mx`


### PR DESCRIPTION
I believe the `CSS Key` of the System Prop `m` should be `margin` instead of `padding`?